### PR TITLE
✨ Introduces Release Drafter 

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,23 @@
+# Please note that emoji usages follows this guide: https://gitmoji.dev/
+---
+categories:
+  - title: '✨ New Features/ Enhancements'
+    labels:
+      - 'feature'
+      - 'enhancement'
+      - 'feat'
+      - 'improvement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '📝 Documentation'
+    labels:
+      - 'documentation'
+      - 'doc'
+      - 'docs'
+exclude-labels:
+  - 'skip-changelog'
+  - 'work-in-progress'
+...

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,17 @@
+---
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          # This token is generated automatically by default in GitHub Actions: no need to create it manually
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+...


### PR DESCRIPTION
This PR introduces the support for release drafter (https://github.com/release-drafter/release-drafter) in the principal branch `main`.

It uses the GitHub action distribution of release-drafter to ensure that a changelog is always generated.