### PR TITLE
✨ Add tfsec 0.37.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,15 @@ RUN curl --silent --show-error --location --output /tmp/terraform.zip \
   && rm -f /tmp/terraform.zip \
   && terraform --version | grep "${TERRAFORM_VERSION}"
 
+ARG TFSEC_VERSION=0.37.1
+ARG TFSEC_SHA256=29adc26d88659bc727a0e02546067c1c8398797f5c5bc248abee6e32393f2f20
+RUN curl --silent --show-error --location --output /tmp/tfsec \
+    "https://github.com/tfsec/tfsec/releases/download/v${TFSEC_VERSION}/tfsec-linux-amd64" \
+  && sha256sum /tmp/tfsec | grep -q "${TFSEC_SHA256}" \
+  && chmod a+x /tmp/tfsec \
+  && mv /tmp/tfsec /usr/local/bin/tfsec \
+  && tfsec --version | grep "${TFSEC_VERSION}"
+
 ENV USER=infra
 ENV HOME=/home/"${USER}"
 

--- a/cst.yml
+++ b/cst.yml
@@ -40,6 +40,10 @@ fileExistenceTests:
     path: '/usr/local/bin/terraform'
     shouldExist: true
     isExecutableBy: 'any'
+  - name: 'tfsec CLI'
+    path: '/usr/local/bin/tfsec'
+    shouldExist: true
+    isExecutableBy: 'any'
   - name: 'Terraform Archive must be cleaned up'
     path: '/tmp/terraform.zip'
     shouldExist: false


### PR DESCRIPTION
This PR adds tfsec in its `0.37.1` version (https://github.com/tfsec/tfsec/releases/tag/v0.37…1).

It allows to run static analysis of the Terraforma projects within the image
