### PR TITLE
✨ Install git v2 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
   # Used to download binaries (implies the package "ca-certificates" as a dependency)
   curl=~7 \
   # Dev. Tooling packages (e.g. tools provided by this image installable through Alpine Linux Packages)
+  git=~2 \
   make=~4 \
   # Used to unarchive Terraform downloads
   unzip=~6

--- a/cst.yml
+++ b/cst.yml
@@ -28,6 +28,10 @@ fileExistenceTests:
     path: '/usr/bin/curl'
     shouldExist: true
     isExecutableBy: 'any'
+  - name: 'Git'
+    path: '/usr/bin/git'
+    shouldExist: true
+    isExecutableBy: 'any'
   - name: 'Make'
     path: '/usr/bin/make'
     shouldExist: true


### PR DESCRIPTION
To allow terraform to retrieve its modules from git repositories.

With the `1.0.0` image, the following error is printed when running `terraform init`on a project using the eks module:

```
Initializing modules...
Downloading terraform-aws-modules/eks/aws 13.2.1 for eks...
Downloading terraform-aws-modules/vpc/aws 2.6.0 for vpc...

Error: Failed to download module

Could not download module "eks" (eks-cluster.tf:1) source code from
"git::https://github.com/terraform-aws-modules/terraform-aws-eks?ref=v13.2.1":
error downloading
'https://github.com/terraform-aws-modules/terraform-aws-eks?ref=v13.2.1': git
must be available and on the PATH.

```