### PR TITLE
chore: fix updatecli configurations

### DIFF
--- a/updatecli/updatecli.d/golang.yml
+++ b/updatecli/updatecli.d/golang.yml
@@ -1,12 +1,9 @@
 ---
-title: "[golang base image] Bump version"
-PipelineID: updatecliToolsUpdates
+title: "Bump golang version"
 sources:
   getGolangVersion:
     kind: githubRelease
     name: Get the latest Golang version
-    transformers:
-      - trimPrefix: "go"
     spec:
       owner: "golang"
       repository: "go"
@@ -15,8 +12,10 @@ sources:
       versionFilter:
         kind: regex
         pattern: 'go1.15.(\d*)'
+    transformers:
+      - trimPrefix: "go"
 conditions:
-  dockerfileArgGoVersion:
+  testDockerfileArgGoVersion:
     name: "Does the Dockerfile have an ARG instruction which key is GO_VERSION?"
     kind: dockerfile
     spec:
@@ -24,9 +23,16 @@ conditions:
       instruction:
         keyword: "ARG"
         matcher: "GO_VERSION"
+  testCstGolangVersion:
+    name: "Does the test harness checks for a label label io.jenkins-infra.tools.golang.version?"
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[2].key"
+      value: io.jenkins-infra.tools.golang.version
 targets:
   updateCstGoVersion:
-    name: "Update the value of GO_VERSION in the test harness"
+    name: "Update the label io.jenkins-infra.tools.golang.version in the test harness"
     sourceID: getGolangVersion
     kind: yaml
     spec:

--- a/updatecli/updatecli.d/golangcilint.yml
+++ b/updatecli/updatecli.d/golangcilint.yml
@@ -1,12 +1,9 @@
 ---
-title: "[Golangcilint] Bump version"
-PipelineID: updatecliToolsUpdates
+title: "Bump golangci-lint version"
 sources:
   getGolangcilintVersion:
     kind: githubRelease
     name: Get the latest Golangcilint version
-    transformers:
-      - trimPrefix: "v"
     spec:
       owner: "golangci"
       repository: "golangci-lint"
@@ -14,8 +11,10 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: latest
+    transformers:
+      - trimPrefix: "v"
 conditions:
-  dockerfileArgGolangcilintVersion:
+  testDockerfileArgGolangcilintVersion:
     name: "Does the Dockerfile have an ARG instruction which key is GOLANGCILINT_VERSION?"
     kind: dockerfile
     spec:
@@ -23,9 +22,16 @@ conditions:
       instruction:
         keyword: "ARG"
         matcher: "GOLANGCILINT_VERSION"
+  testCstGolangciLintVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.golangci-lint.version?"
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[4].key"
+      value: io.jenkins-infra.tools.golangci-lint.version
 targets:
   updateCstGolangcilintVersion:
-    name: "Update the value of GOLANGCILINT_VERSION in the test harness"
+    name: "Update the label io.jenkins-infra.tools.golangci-lint.version in the test harness"
     sourceID: getGolangcilintVersion
     kind: yaml
     spec:

--- a/updatecli/updatecli.d/terraform.yml
+++ b/updatecli/updatecli.d/terraform.yml
@@ -1,12 +1,9 @@
 ---
-title: "[Terraform] Bump version"
-PipelineID: updatecliToolsUpdates
+title: "Bump terraform version"
 sources:
   getTerraformVersion:
     kind: githubRelease
     name: Get the latest Terraform version
-    transformers:
-      - trimPrefix: "v"
     spec:
       owner: "hashicorp"
       repository: "terraform"
@@ -15,8 +12,10 @@ sources:
       versionFilter:
         kind: regex
         pattern: '0.13.(\d*)'
+    transformers:
+      - trimPrefix: "v"
 conditions:
-  dockerfileArgTerraformVersion:
+  testDockerfileArgTerraformVersion:
     name: "Does the Dockerfile have an ARG instruction which key is TERRAFORM_VERSION?"
     kind: dockerfile
     spec:
@@ -24,14 +23,21 @@ conditions:
       instruction:
         keyword: "ARG"
         matcher: "TERRAFORM_VERSION"
+  testCstTerraformVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.terraform.version?"
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[1].key"
+      value: io.jenkins-infra.tools.terraform.version
 targets:
   updateCstTerraformVersion:
-    name: "Update the value of TERRAFORM_VERSION in the test harness"
+    name: "Update the label io.jenkins-infra.tools.terraform.version in the test harness"
     sourceID: getTerraformVersion
     kind: yaml
     spec:
       file: "cst.yml"
-      key: "metadataTest.labels[2].value"
+      key: "metadataTest.labels[1].value"
     scm:
       github:
         user: "{{ .github.user }}"

--- a/updatecli/updatecli.d/tfsec.yml
+++ b/updatecli/updatecli.d/tfsec.yml
@@ -1,12 +1,9 @@
 ---
-title: "[Tfsec] Bump version"
-PipelineID: updatecliToolsUpdates
+title: "Bump tfsec version"
 sources:
   getTfsecVersion:
     kind: githubRelease
     name: Get the latest Tfsec version
-    transformers:
-      - trimPrefix: "v"
     spec:
       owner: "tfsec"
       repository: "tfsec"
@@ -14,8 +11,10 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: latest
+    transformers:
+      - trimPrefix: "v"
 conditions:
-  dockerfileArgTfsecVersion:
+  testDockerfileArgTfsecVersion:
     name: "Does the Dockerfile have an ARG instruction which key is TFSEC_VERSION?"
     kind: dockerfile
     spec:
@@ -23,9 +22,16 @@ conditions:
       instruction:
         keyword: "ARG"
         matcher: "TFSEC_VERSION"
+  testCstTfsecVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.tfsec.version?"
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "metadataTest.labels[3].key"
+      value: io.jenkins-infra.tools.tfsec.version
 targets:
   updateCstTfsecVersion:
-    name: "Update the value of TFSEC_VERSION in the test harness"
+    name: "Update the label io.jenkins-infra.tools.tfsec.version in the test harness"
     sourceID: getTfsecVersion
     kind: yaml
     spec:


### PR DESCRIPTION
This PR tries to fix the broken updatecli PRs by:

- Removing the "pipelineID" marker
- Fixing the terraform updatecli config which was not updating the correct element in `cst.yml` file
- Add a test, based on @olblak feedbacks, for the `cst.yml` key
- A bit of syntactic sugar to improve understanding