### PR TITLE
feat: bump terraform to 1.0.4 + force updatecli on terraform 1.0.x versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # For instance: "
 # TERRAFORM_VERSION=X.YY.Z
 # curl -sSL https://releases.hashicorp.com/terraform/$TERRAFORM_VERSION/terraform_$TERRAFORM_VERSION_SHA256SUMS | grep linux_amd64
-ARG TERRAFORM_VERSION=0.13.7
+ARG TERRAFORM_VERSION=1.0.4
 RUN curl --silent --show-error --location --output /tmp/terraform.zip \
     "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
   && unzip /tmp/terraform.zip -d /usr/local/bin \

--- a/cst.yml
+++ b/cst.yml
@@ -9,7 +9,7 @@ metadataTest:
     - key: io.jenkins-infra.tools
       value: "golang,terraform,tfsec,golangci-lint,aws-cli"
     - key: io.jenkins-infra.tools.terraform.version
-      value: "0.13.7"
+      value: "1.0.4"
     - key: io.jenkins-infra.tools.golang.version
       value: "1.16.7"
     - key: io.jenkins-infra.tools.tfsec.version

--- a/updatecli/updatecli.d/terraform.yml
+++ b/updatecli/updatecli.d/terraform.yml
@@ -11,7 +11,7 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: regex
-        pattern: '0.13.(\d*)'
+        pattern: '1.0.(\d*)'
     transformers:
       - trimPrefix: "v"
 conditions:


### PR DESCRIPTION
This PR bumps Terraform to 1.0.4. This is a major change which has been tested on the following infrastructures repositories:

- AWS (https://github.com/jenkins-infra/aws/pull/23)
- Datadog (https://github.com/jenkins-infra/datadog/pull/32)

But not on Azure (https://github.com/jenkins-infra/azure) because it's not an automated repository.