### PR TITLE
feat(golang) bump golang to 1.17 mainline (1.17.3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # Golang is required for terratest
 # 1.15 ensure that the latest patch is always used but avoiding breaking changes when Golang as a minor upgrade
 # Alpine is used by default for fast and ligthweight customization
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.17.3
 FROM golang:"${GO_VERSION}-alpine"
 
 ## Repeating the ARG to add it into the scope of this image
-ARG GO_VERSION=1.16.9
+ARG GO_VERSION=1.17.3
 
 RUN apk add --no-cache \
   # To allow easier CLI completion + running shell scripts with array support

--- a/cst.yml
+++ b/cst.yml
@@ -11,7 +11,7 @@ metadataTest:
     - key: io.jenkins-infra.tools.terraform.version
       value: "1.0.10"
     - key: io.jenkins-infra.tools.golang.version
-      value: "1.16.9"
+      value: "1.17.3"
     - key: io.jenkins-infra.tools.tfsec.version
       value: "0.58.15"
     - key: io.jenkins-infra.tools.golangci-lint.version

--- a/updatecli/updatecli.d/golang.yml
+++ b/updatecli/updatecli.d/golang.yml
@@ -11,7 +11,7 @@ sources:
       username: "{{ .github.username }}"
       versionFilter:
         kind: regex
-        pattern: 'go1.16.(\d*)'
+        pattern: 'go1.17.(\d*)'
     transformers:
       - trimPrefix: "go"
 conditions:


### PR DESCRIPTION
Signed-off-by: Damien Duportal <damien.duportal@gmail.com>